### PR TITLE
RFC: Make build github action re-usable and callable

### DIFF
--- a/.github/workflows/extract_branch_info.yml
+++ b/.github/workflows/extract_branch_info.yml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: BSD-2-Clause
+# X-SPDX-Copyright-Text: (c) Copyright 2024 Advanced Micro Devices, Inc.
+
+name: "perform_build"
+
+on:
+  push:
+  pull_request:
+    types: [opened]
+
+jobs:
+  extract_branch_info:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      tcpdirectBranch: ${{ steps.tcpdirectBranch.outputs.branch }}
+      onloadBranch: ${{ steps.onloadBranch.outputs.branch }}
+      packetDrillBranch: ${{ steps.packetDrillBranch.outputs.branch }}
+      tcpdirectRepo: ${{ steps.tcpdirectRepo.outputs.branch }}
+      onloadRepo: ${{ steps.onloadRepo.outputs.branch }}
+      packetDrillRepo: ${{ steps.packetDrillRepo.outputs.branch }}
+    steps:
+      - name: tcpdirect
+        uses: actions/checkout@v4
+        with:
+          path: tcpdirect
+
+      - name: Install yq
+        run: |
+           sudo apt-get update
+           sudo apt-get install -y python3 python3-pip jq
+           pip3 install yq
+
+      - name: Extract TCPDirect branch name
+        id: tcpdirectBranch
+        run: echo "branch=master" >> "$GITHUB_OUTPUT"
+
+      - name: Extract onload branch name
+        id: onloadBranch
+        run: echo "branch=$(yq -r '.products.Onload.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract packetDrill branch name
+        id: packetDrillBranch
+        run: echo "branch=$(yq -r '.products.Packetdrill.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
+
+      - name: Extract TCPDirect repository name
+        id: tcpdirectRepo
+        run: echo "branch=${{ github.repository }}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract onload repository name
+        id: onloadRepo
+        run: echo "branch=$(yq -r '.products.Onload.repo_source' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml | sed -E -e 's/^\s*.*://g' -e 's/\.git$//g')" >> "$GITHUB_OUTPUT"
+
+      - name: Extract packetDrill repository name
+        id: packetDrillRepo
+        run: echo "branch=$(yq -r '.products.Packetdrill.repo_source' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml | sed -E -e 's/^\s*.*://g' -e 's/\.git$//g')" >> "$GITHUB_OUTPUT"
+
+  perform_build_and_test:
+    needs: extract_branch_info
+    uses: ./.github/workflows/perform_build.yml
+    with:
+      onloadBranch: ${{ needs.extract_branch_info.outputs.onloadBranch }}
+      onloadRepo: ${{ needs.extract_branch_info.outputs.onloadRepo }}
+      tcpdirectBranch: ${{ needs.extract_branch_info.outputs.tcpdirectBranch }}
+      tcpdirectRepo: ${{ needs.extract_branch_info.outputs.tcpdirectRepo }}
+      packetdrillBranch: ${{ needs.extract_branch_info.outputs.packetDrillBranch }}
+      packetdrillRepo: ${{ needs.extract_branch_info.outputs.packetDrillRepo }}
+    secrets: inherit
+

--- a/.github/workflows/perform_build.yml
+++ b/.github/workflows/perform_build.yml
@@ -4,69 +4,72 @@
 name: "perform_build"
 
 on:
-  push:
-  pull_request:
-    types: [opened]
+  workflow_call:
+    inputs:
+      onloadBranch:
+        description: "Version of onload to be built against"
+        default: "master"
+        required: true
+        type: string
+      onloadRepo:
+        description: "Onload repository to checkout"
+        default: "Xilinx-CNS/onload"
+        required: true
+        type: string
+      tcpdirectBranch:
+        description: "Version of tcpdirect to build"
+        default: "master"
+        required: true
+        type: string
+      tcpdirectRepo:
+        description: "Version of tcpdirect to build"
+        default: "Xilinx-CNS/tcpdirect"
+        required: true
+        type: string
+      packetDrillBranch:
+        description: "Version of onload to be built against"
+        default: "master"
+        required: true
+        type: string
+      packetDrillRepo:
+        description: "Version of onload to be built against"
+        default: "Xilinx-CNS/packetdrill-tcpdirect"
+        required: true
+        type: string
+    secrets:
+      PAT:
+        required: true
+
 
 jobs:
-  extract_branch_info:
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    outputs:
-      tcpdirectBranch: ${{ steps.tcpdirectBranch.outputs.branch }}
-      onloadBranch: ${{ steps.onloadBranch.outputs.branch }}
-      packetDrillBranch: ${{ steps.packetDrillBranch.outputs.branch }}
-    steps:
-      - name: tcpdirect
-        uses: actions/checkout@v4
-        with:
-          path: tcpdirect
-
-      - name: Install yq
-        run: |
-           sudo apt-get update
-           sudo apt-get install -y python3 python3-pip jq
-           pip3 install yq
-
-      - name: Extract TCPDirect branch name
-        id: tcpdirectBranch
-        run: echo "branch=$(yq -r '.products.TCPDirect.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
-
-      - name: Extract onload branch name
-        id: onloadBranch
-        run: echo "branch=$(yq -r '.products.Onload.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
-
-      - name: Extract packetDrill branch name
-        id: packetDrillBranch
-        run: echo "branch=$(yq -r '.products.Packetdrill.version' < $GITHUB_WORKSPACE/tcpdirect/versions.yaml)" >> "$GITHUB_OUTPUT"
-
-
   perform_build_and_test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: extract_branch_info
     steps:
-
       - name: tcpdirect
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.tcpdirectRepo }}
           path: tcpdirect
+          ref: ${{ inputs.tcpdirectBranch }}
+          token: ${{ secrets.PAT }}
 
       - name: onload checkout
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.repository_owner }}/onload
+          repository: ${{ inputs.onloadRepo }}
           path: onload
-          ref: ${{ needs.extract_branch_info.outputs.onloadBranch }}
+          ref: ${{ inputs.onloadBranch }}
+          token: ${{ secrets.PAT }}
 
       - name: packetdrill checkout
         uses: actions/checkout@v4
         continue-on-error: true
         with:
-          repository: ${{ github.repository_owner }}/packetdrill-tcpdirect
+          repository: ${{ inputs.packetDrillRepo }}
           path: packetdrill-tcpdirect
-          ssh-key: ${{ secrets.PACKET_DRILL_PRIVATE_KEY }}
-          ref: ${{ needs.extract_branch_info.outputs.packetDrillBranch }}
+          ref: ${{ inputs.packetDrillBranch }}
+          token: ${{ secrets.PAT }}
 
       - name: Install TCPDirect Deps
         run: |


### PR DESCRIPTION
## Actions

### Current actions
Our current github action for building testing changes has 2 jobs each with multiple steps:
1. Parse `versions.yaml` to get git repos and branches
2. Checkout, build and run unit tests.

The current actions are run on each push and pull request.

### Proposed changes
This PR further separates these two jobs into 2 actions, essentially following the same distinction as the current jobs.
However, the building job will become a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) and so is not triggered by a push/PR instead it is started by another action.

The current job that extracts the branch information will become a new action that is triggered on a push/PR, then when the branches and repos have been extracted it calls the other action which performs the actual building and testing.

This should allow for a github action on the onload internal repo to check that an onload change does not affect tcpdirect and should allow us to find build issues before changes are merged. I have a simple prototype on my onload fork the calls into this action on each push/PR.

Please see tcrawley-xilinx/onload_internal#1 for corresponding onload changes


### Security 
Since we will want to checkout private repos we will have to provide some kind of security token so that they can be checked out.
I'm not able to see the current variables/secrets on either onload_internal or tcpdirect so I don't know what currently exists apart from the reference to `secrets.PACKET_DRILL_PRIVATE_KEY`. As such I've just chosen to create a personal access token (PAT) which has permissions to checkout repos and put it as a secret on my forks of tcpdirect and onload_internal.